### PR TITLE
Improved handling of Internet Date-times, particularly time zones.

### DIFF
--- a/R/loadDataFrame.R
+++ b/R/loadDataFrame.R
@@ -113,6 +113,7 @@ loadDataFrame <- function(info, project, include.nested=TRUE, parallel=TRUE) {
             df[[i]] <- as.Date(df[[i]])
 
         } else if (col.type=="date-time") {
+            # Remove colon in the timezone, which confuses as.POSIXct().
             df[[i]] <- as.POSIXct(sub(":([0-9]{2})$", "\\1", df[[i]]), format="%Y-%m-%dT%H:%M:%S%z")
 
         } else if (col.type %in% names(atomics)) {

--- a/tests/testthat/test-list.R
+++ b/tests/testthat/test-list.R
@@ -308,7 +308,7 @@ test_that("we handle lists with NULLs", {
 })
 
 test_that("we handle lists with times", {
-    now <- as.POSIXct(round(Sys.time()))         
+    now <- as.POSIXct(round(Sys.time()), tz="")
     vals <- list(now, list(list(now + 10000), c(X=now + 400000, Y=now + 1000000)))
 
     tmp <- tempfile()


### PR DESCRIPTION
C++ code defines a separate subclass for date-time, so as to avoid mixing up the special handlers with the regular typed vectors.

Testing now uses a fixed tz= to avoid locale-specific surprises when converting from a POSIXlt object (e.g., as in Sys.time()).